### PR TITLE
Jade folders

### DIFF
--- a/public/scripts/newevent.js
+++ b/public/scripts/newevent.js
@@ -1,0 +1,27 @@
+// AJAX call for autocomplete
+$(document).ready(function () {
+	$("#submit-button").click(function () {
+		$.ajax({
+			type: "POST",
+			url: "/api/events/",
+			headers: {
+				"Client": "Fest-Manager/dash"
+			},
+			data: {
+				name: $('#field-name').val(),
+				tagline: $('#field-tagline').val(),
+				category: $('#field-category').val(),
+				body: $('#field-body').text(), // span element
+				about: $('#field-about').val(),
+				startTime: $('#field-startTime').val(),
+				endTime: $('#field-endTime').val(),
+			},
+			success: function (data, textStatus, req) {
+				console.log(req);
+				if (data == "Success") {
+					manager.route('/portals');
+				}
+			}
+		})
+	})
+});

--- a/routes/components/portals.js
+++ b/routes/components/portals.js
@@ -25,6 +25,114 @@ router.get('/', authenticate, elevate, function (req, res, next) {
 	}
 });
 
+var getFields = function (user, orgbody) {
+	var fields = [];
+	fields.push({
+		icon: "name",
+		name: "name",
+		label: "Name",
+		editable: true,
+		type: "text",
+		required: true,
+		value: "",
+		typeahead: false,
+		none: true,
+	});
+	fields.push({
+		icon: "tagline",
+		name: "tagline",
+		label: "Tagline",
+		editable: true,
+		type: "text",
+		required: true,
+		value: "",
+		typeahead: false,
+		none: true,
+	});
+	fields.push({
+		icon: "about",
+		name: "about",
+		label: "Description",
+		editable: true,
+		type: "textarea",
+		required: true,
+		value: "",
+		typeahead: false,
+		none: true,
+	});
+	fields.push({
+		icon: "body",
+		name: "body",
+		label: "Organiser",
+		editable: false,
+		type: "text",
+		required: true,
+		value: orgbody._id,
+		typeahead: false,
+		none: true,
+	});
+	fields.push({
+		icon: "category",
+		name: "category",
+		label: "Category",
+		editable: true,
+		type: "select",
+		options: ["Cat1", "Cat2", "Cat3"],
+		required: true,
+		value: "Cat1",
+		typeahead: false,
+		none: true,
+	});
+	fields.push({
+		icon: "startTime",
+		name: "startTime",
+		label: "Start Time",
+		editable: true,
+		type: "date",
+		required: true,
+		value: null,
+		typeahead: false,
+		none: true,
+	});
+	fields.push({
+		icon: "endTime",
+		name: "endTime",
+		label: "End Time",
+		editable: true,
+		type: "date",
+		required: true,
+		value: null,
+		typeahead: false,
+		none: true,
+	});
+	return fields;
+};
+
+router.get('/:body/events/new', authenticate, elevate, function (req, res, next) {
+	if (req.params.body != req.user.privilege.body && req.user.privilege.level != 2) {
+		var error = new Error('Access Denied');
+		error.status = 403;
+		return next(error);
+	}
+	bodiesService.findOne({
+		code: req.params.body
+	}, function (err, item) {
+		if (err || !item) {
+			var error = new Error('Not Found');
+			error.status = 404;
+			return next(error);
+		}
+		console.log("Item:", item);
+		var params = {
+			title: 'Add new event',
+			user: req.user,
+			body: item,
+		};
+		params.fields = getFields(req.user, item);
+		res.renderState('portals/newevent', params);
+	});
+});
+
 router.get('/:body', authenticate, elevate, function (req, res, next) {
 	if (req.params.body != req.user.privilege.body && req.user.privilege.level != 2) {
 		var error = new Error('Access Denied');

--- a/views/mixins/field.jade
+++ b/views/mixins/field.jade
@@ -14,7 +14,9 @@ mixin fieldMixin(data)
 					select(id="field-#{data.name}" type=data.type placeholder=data.placeholder required=data.required value=data.value)
 						each option in data.options
 							option(value=option)= option
+				else if data.type == "textarea"
+					textarea(id="field-#{data.name}" type=data.type placeholder=data.placeholder required=data.required value=data.value rows="4")
 				else
 					input(id="field-#{data.name}" type=data.type placeholder=data.placeholder required=data.required value=data.value)
 			else
-				span= data.value
+				span(id="field-#{data.name}")= data.value

--- a/views/mixins/field.jade
+++ b/views/mixins/field.jade
@@ -10,6 +10,10 @@ mixin fieldMixin(data)
 				if data.typeahead
 					input(id="field-#{data.name}" name=data.name type=data.type placeholder=data.placeholder required=data.required list="list-#{data.name}" value=data.value)
 					+datalistMixin(data)
+				else if data.type == "select"
+					select(id="field-#{data.name}" type=data.type placeholder=data.placeholder required=data.required value=data.value)
+						each option in data.options
+							option(value=option)= option
 				else
 					input(id="field-#{data.name}" type=data.type placeholder=data.placeholder required=data.required value=data.value)
 			else

--- a/views/portals/newevent.jade
+++ b/views/portals/newevent.jade
@@ -1,0 +1,14 @@
+title= title
+include ../mixins/field
+
+div.section.header
+	h1= title
+	div.stretch
+			div.remnant
+				ul.controls
+					li.icon-check#submit-button(tooltip="Save")
+					li.icon-close#cancel-button(_route="/dashboard" tooltip="Cancel")
+form.container(method="PUT" action="/api/users/me")
+	each field in fields
+		+fieldMixin(field)
+script(src="/scripts/newevent.js")

--- a/views/portals_home.jade
+++ b/views/portals_home.jade
@@ -2,5 +2,5 @@ title= title
 i.meta(_routed_at="/portals")
 h1 Your Organisations
 each body in bodies
-	a(_route= 'portals/bodies/' + body.code)
+	a(_route= 'portals/' + body.code)
 		h2= body.name


### PR DESCRIPTION
Review this.

After we merge this we need to do the following tasks

1. Route the (+) button on `/portals/:body` pages to `/portals/:body/events/new`.
2. Add CSS for `<select>` tag.
3. Add CSS for `<textarea>` tag.
4. Add a datepicker using JQuery and update respective code in the `field.jade` mixin.
5. Generalize submit form syntax on the frontend so that we can keep files like `register.js` and `newevent.js` small, that call a generic function in `form-handler.js`.