### PR TITLE
auth: Add google image url storage for existing accounts. Fixes #76.

### DIFF
--- a/utils/authentication.js
+++ b/utils/authentication.js
@@ -42,6 +42,9 @@ var findOrCreate = function (accessToken, profile, provider, done) {
 				});
 
 			}
+			if(provider == 'googleID'){
+					user.profileImage = profile._json.image.url;
+				}
 
 			if (!user[provider] || !user.name) { //check if same email has connected with a second provider
 				user[provider] = profile.id;


### PR DESCRIPTION
Fixed google image not showing up for logged in users