### PR TITLE
Make submenus dynamic

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ app.use(function (req, res, next) {
 		var state = stateHandler.getState(req);
 		res.render(filename, options, function (err, string) {
 			//Uncomment the line below to observe the error in case a jade template breaks.
-			//console.log(err, string)
+			// console.log(err, string)
 			res.send({
 				html: string,
 				state: state,

--- a/app.js
+++ b/app.js
@@ -64,6 +64,7 @@ let clientCheckpoint = function (req, res, next) {
 };
 
 app.use(function (req, res, next) {
+	req.stateparams = {};
 	res.renderState = function (filename, options) {
 		var state = stateHandler.getState(req);
 		res.render(filename, options, function (err, string) {

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -1,12 +1,12 @@
-$('document').ready(function() {
-    $('.event-container').click(function() {
-        $('.events-wrapper').addClass('blur');
-        $(this).addClass('active');
-        $('.open-event').addClass('focus');
-    });
-    $('.open-event .icon-close').click(function() {
-        $('.events-wrapper').removeClass('blur');
-        $('.event-container.active').removeClass('active');
-        $('.open-event').removeClass('focus');
-    });
+$('document').ready(function () {
+	$('.event-container').click(function () {
+		$('.events-wrapper').addClass('blur');
+		$(this).addClass('active');
+		$('.open-event').addClass('focus');
+	});
+	$('.open-event .icon-close').click(function () {
+		$('.events-wrapper').removeClass('blur');
+		$('.event-container.active').removeClass('active');
+		$('.open-event').removeClass('focus');
+	});
 })

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -11,6 +11,8 @@ var manager = function () {
 				menu: {},
 			},
 			user: {},
+			submenu: {},
+			title: "",
 		}
 	});
 	client.route = function (route, status = true) {
@@ -44,6 +46,7 @@ var manager = function () {
 				}, 500);
 				client.removeClass('loading');
 			});
+			this.navigation.generateSubMenu(data.state);
 			this.main.initialize();
 			this.main.stageEventHandlers();
 			this.main.focus();
@@ -74,6 +77,30 @@ var manager = function () {
 		});
 	}
 
+	client.navigation.generateSubMenu = function (state) {
+		if (!state.submenu.length > 0) {
+			holder.removeClass('avtice');
+			return;
+		}
+		var holder = $('.section.secondary');
+		holder.addClass('active');
+		holder.find('label').text(state.title);
+		holder.find('ul').empty();
+		state.submenu.forEach(function (menuitem) {
+			var htmlstring = '<li';
+			if (menuitem.route) {
+				htmlstring += ' _route="' + state.location.split('components/')[1] + menuitem.route + '"';
+			}
+			htmlstring += '>' + '<i></i>';
+			if (menuitem.label) {
+				htmlstring += '<span>' + menuitem.label + '</span>';
+			}
+			htmlstring += "</li>";
+			holder.find('ul').append(htmlstring);
+		});
+		client.navigation.stageEventHandlers();
+	}
+
 	client.stageEventHandlers = function () {
 		this.initialize();
 		this.main.stageEventHandlers();
@@ -86,7 +113,14 @@ var manager = function () {
 			$(".window > .remnant").removeClass("shift_to_expose_menu");
 		});
 	}
-	client.navigation.stageEventHandlers = function () {};
+	client.navigation.stageEventHandlers = function () {
+		$(this).find('[href]').click(function (e) {
+			window.location.assign($(this).attr("href"));
+		});
+		$(this).find('[_route]').click(function (e) {
+			client.route($(this).attr('_route'));
+		})
+	};
 	client.header.stageEventHandlers = function () {
 		$('#menu').click(function () {
 			$(".window > .remnant").toggleClass("shift_to_expose_menu");

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -89,7 +89,7 @@ var manager = function () {
 		state.submenu.forEach(function (menuitem) {
 			var htmlstring = '<li';
 			if (menuitem.route) {
-				htmlstring += ' _route="' + state.location.split('components/')[1] + menuitem.route + '"';
+				htmlstring += ' _route="' + menuitem.route + '"';
 			}
 			htmlstring += '>' + '<i></i>';
 			if (menuitem.label) {

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -94,7 +94,7 @@ var manager = function () {
 				$(".sidebar").focus();
 				client.main.stageEventHandlers();
 			}
-			$(".navbar .icon-close").click(function() {
+			$(".navbar .icon-close").click(function () {
 				window.history.back();
 			});
 		})

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -84,7 +84,8 @@ var manager = function () {
 		}
 		var holder = $('.section.secondary');
 		holder.addClass('active');
-		holder.find('label').text(state.title);
+		holder.find('label').text(state.title.text);
+		holder.find('label').attr('_route', state.title.route)
 		holder.find('ul').empty();
 		state.submenu.forEach(function (menuitem) {
 			var htmlstring = '<li';

--- a/routes/components/custom.js
+++ b/routes/components/custom.js
@@ -1,0 +1,9 @@
+var express = require('express');
+var router = express.Router();
+var eventsService = require("../api/services/events").model;
+
+// Load custom modules here
+
+router.use('/pybits', require('./custom/pybits'));
+
+module.exports = router;

--- a/routes/components/custom/pybits.js
+++ b/routes/components/custom/pybits.js
@@ -1,0 +1,58 @@
+var express = require('express');
+var router = express.Router();
+
+
+var applyStateChanges = function (req) {
+	req.stateparams.title = {
+		text: 'PyBits',
+		route: 'pybits',
+	};
+	req.stateparams.submenu = [{
+			label: "Talks",
+			route: "/pybits/talks",
+		},
+		{
+			label: "Sprints",
+			route: "/pybits/sprints",
+		},
+		{
+			label: "Workshops",
+			route: "/pybits/workshops",
+		}
+	];
+	return req;
+};
+
+router.get('/', function (req, res, next) {
+	req = applyStateChanges(req);
+	res.renderState('custom/pybits/home', {
+		title: 'PyBits',
+		user: req.user,
+	});
+});
+
+router.get('/talks', function (req, res, next) {
+	req = applyStateChanges(req);
+	res.renderState('custom/pybits/talks', {
+		title: 'PyBits Talks',
+		user: req.user,
+	});
+});
+
+router.get('/sprints', function (req, res, next) {
+	req = applyStateChanges(req);
+	res.renderState('custom/pybits/sprints', {
+		title: 'PyBits Sprints',
+		user: req.user,
+	});
+});
+
+router.get('/workshops', function (req, res, next) {
+	req = applyStateChanges(req);
+	res.renderState('custom/pybits/workshops', {
+		title: 'PyBits Workshops',
+		user: req.user,
+	});
+});
+
+module.exports = router;

--- a/routes/components/dashboard.js
+++ b/routes/components/dashboard.js
@@ -48,11 +48,11 @@ router.get('/', authenticate, function (req, res, next) {
 	};
 	req.stateparams.title = 'Dashboard';
 	req.stateparams.submenu = [{
-			route: "/account",
+			route: "/dashboard/account",
 			label: "Account"
 		},
 		{
-			route: "/cart",
+			route: "/dashboard/cart",
 			label: "Cart"
 		}
 	];
@@ -66,11 +66,11 @@ router.get('/account', authenticate, function (req, res, next) {
 	};
 	req.stateparams.title = 'Dashboard';
 	req.stateparams.submenu = [{
-			route: "/account",
+			route: "/dashboard/account",
 			label: "Account"
 		},
 		{
-			route: "/cart",
+			route: "/dashboard/cart",
 			label: "Cart"
 		}
 	];

--- a/routes/components/dashboard.js
+++ b/routes/components/dashboard.js
@@ -46,7 +46,10 @@ router.get('/', authenticate, function (req, res, next) {
 		user: req.user,
 		title: "Dashboard"
 	};
-	req.stateparams.title = 'Dashboard';
+	req.stateparams.title = req.stateparams.title = {
+		text: 'Dashboard',
+		route: '/dashboard',
+	};
 	req.stateparams.submenu = [{
 			route: "/dashboard/account",
 			label: "Account"
@@ -64,7 +67,10 @@ router.get('/account', authenticate, function (req, res, next) {
 		title: 'My Account',
 		user: req.user,
 	};
-	req.stateparams.title = 'Dashboard';
+	req.stateparams.title = req.stateparams.title = {
+		text: 'Dashboard',
+		route: '/dashboard',
+	};
 	req.stateparams.submenu = [{
 			route: "/dashboard/account",
 			label: "Account"

--- a/routes/components/dashboard.js
+++ b/routes/components/dashboard.js
@@ -64,16 +64,16 @@ router.get('/account', authenticate, function (req, res, next) {
 		title: 'My Account',
 		user: req.user,
 	};
-	req.stateparams.submenu = {
-		account: {
+	req.stateparams.submenu = [
+		{
 			route: "/account",
 			label: "Account"
 		},
-		cart: {
+		{
 			route: "/cart",
 			label: "Cart"
 		}
-	};
+	];
 	params.fields = getFields(req.user);
 	res.renderState('account', params);
 });

--- a/routes/components/dashboard.js
+++ b/routes/components/dashboard.js
@@ -46,6 +46,16 @@ router.get('/', authenticate, function (req, res, next) {
 		user: req.user,
 		title: "Dashboard"
 	};
+	req.stateparams.submenu = {
+		account: {
+			route: "/account",
+			label: "Account"
+		},
+		cart: {
+			route: "/cart",
+			label: "Cart"
+		}
+	};
 	res.renderState('dashboard', params);
 });
 
@@ -54,7 +64,16 @@ router.get('/account', authenticate, function (req, res, next) {
 		title: 'My Account',
 		user: req.user,
 	};
-	console.log(req.user);
+	req.stateparams.submenu = {
+		account: {
+			route: "/account",
+			label: "Account"
+		},
+		cart: {
+			route: "/cart",
+			label: "Cart"
+		}
+	};
 	params.fields = getFields(req.user);
 	res.renderState('account', params);
 });

--- a/routes/components/dashboard.js
+++ b/routes/components/dashboard.js
@@ -46,16 +46,16 @@ router.get('/', authenticate, function (req, res, next) {
 		user: req.user,
 		title: "Dashboard"
 	};
-	req.stateparams.submenu = {
-		account: {
+	req.stateparams.title = 'Dashboard';
+	req.stateparams.submenu = [{
 			route: "/account",
 			label: "Account"
 		},
-		cart: {
+		{
 			route: "/cart",
 			label: "Cart"
 		}
-	};
+	];
 	res.renderState('dashboard', params);
 });
 
@@ -64,8 +64,8 @@ router.get('/account', authenticate, function (req, res, next) {
 		title: 'My Account',
 		user: req.user,
 	};
-	req.stateparams.submenu = [
-		{
+	req.stateparams.title = 'Dashboard';
+	req.stateparams.submenu = [{
 			route: "/account",
 			label: "Account"
 		},

--- a/routes/components/events.js
+++ b/routes/components/events.js
@@ -6,7 +6,10 @@ var eventsService = require("../api/services/events").model;
 router.get('/', function (req, res, next) {
 	eventsService.find(function (err, events) {
 		if (err) next(err);
-		req.stateparams.title = 'Events';
+		req.stateparams.title = {
+			text: 'Events',
+			route: '/events',
+		};
 		req.stateparams.submenu = [{
 				label: "Competitions"
 			},

--- a/routes/components/events.js
+++ b/routes/components/events.js
@@ -6,6 +6,17 @@ var eventsService = require("../api/services/events").model;
 router.get('/', function (req, res, next) {
 	eventsService.find(function (err, events) {
 		if (err) next(err);
+		req.stateparams.submenu = {
+			comps: {
+				label: "Competitions"
+			},
+			workshops: {
+				label: "Workshops"
+			},
+			shows: {
+				label: "Proshows"
+			}
+		};
 		res.renderState('events', {
 			title: 'Events',
 			user: req.user,
@@ -20,9 +31,7 @@ router.get('/:eventroute', function (req, res, next) {
 	}, function (err, data) {
 		if (err) next(err);
 		if (data.immersive) {
-			req.stateparams = {
-				immersive: true
-			};
+			req.stateparams.immersive = true;
 		}
 		res.renderState('single-event', {
 			title: data.name,

--- a/routes/components/events.js
+++ b/routes/components/events.js
@@ -6,8 +6,8 @@ var eventsService = require("../api/services/events").model;
 router.get('/', function (req, res, next) {
 	eventsService.find(function (err, events) {
 		if (err) next(err);
-		req.stateparams.submenu = [
-			{
+		req.stateparams.title = 'Events';
+		req.stateparams.submenu = [{
 				label: "Competitions"
 			},
 			{

--- a/routes/components/events.js
+++ b/routes/components/events.js
@@ -6,17 +6,17 @@ var eventsService = require("../api/services/events").model;
 router.get('/', function (req, res, next) {
 	eventsService.find(function (err, events) {
 		if (err) next(err);
-		req.stateparams.submenu = {
-			comps: {
+		req.stateparams.submenu = [
+			{
 				label: "Competitions"
 			},
-			workshops: {
+			{
 				label: "Workshops"
 			},
-			shows: {
+			{
 				label: "Proshows"
 			}
-		};
+		];
 		res.renderState('events', {
 			title: 'Events',
 			user: req.user,

--- a/routes/components/index.js
+++ b/routes/components/index.js
@@ -1,5 +1,6 @@
 var express = require('express');
 var router = express.Router();
+var custom = require('./custom');
 var events = require('./events');
 var dashboard = require('./dashboard');
 var portals = require('./portals');
@@ -13,6 +14,7 @@ router.get('/', function (req, res, next) {
 	});
 });
 
+router.use('/', custom);
 router.use('/events', events);
 router.use('/dashboard', dashboard);
 router.use('/portals', portals);

--- a/routes/index.js
+++ b/routes/index.js
@@ -16,17 +16,6 @@ router.get('/?*', function (req, res, next) {
 			events: {
 				label: "Events",
 				route: "/events",
-				sub: {
-					comps: {
-						label: "Competitions"
-					},
-					workshops: {
-						label: "Workshops"
-					},
-					shows: {
-						label: "Proshows"
-					}
-				},
 			},
 			dashboard: {
 				label: "Dashboard",
@@ -36,16 +25,6 @@ router.get('/?*', function (req, res, next) {
 					path: "user/isAuthenticated",
 					for: "visible"
 				},
-				sub: {
-					account: {
-						route: "/account",
-						label: "Account"
-					},
-					cart: {
-						route: "/cart",
-						label: "Cart"
-					}
-				}
 			},
 			portals: {
 				route: "/portals",

--- a/utils/authentication.js
+++ b/utils/authentication.js
@@ -20,7 +20,7 @@ var findOrCreate = function (accessToken, profile, provider, done) {
 					token: accessToken,
 					qrData: url
 				});
-				if(provider == 'googleID'){
+				if (provider == 'googleID') {
 					user.profileImage = profile._json.image.url;
 				}
 				user[provider] = profile.id;
@@ -42,9 +42,9 @@ var findOrCreate = function (accessToken, profile, provider, done) {
 				});
 
 			}
-			if(provider == 'googleID'){
-					user.profileImage = profile._json.image.url;
-				}
+			if (provider == 'googleID') {
+				user.profileImage = profile._json.image.url;
+			}
 
 			if (!user[provider] || !user.name) { //check if same email has connected with a second provider
 				user[provider] = profile.id;

--- a/utils/state.js
+++ b/utils/state.js
@@ -1,5 +1,11 @@
 module.exports = function () {
 
+	var appendStateFromRequest = function (state, req) {
+		// Append supported variables to state.
+		state.submenu = req.stateparams.submenu;
+		return state;
+	};
+
 	var appendUserState = function (state, req) {
 		var user = {};
 		user.isAuthenticated = req.isAuthenticated();
@@ -65,6 +71,7 @@ module.exports = function () {
 		if (req.stateparams && req.stateparams.immersive) {
 			state.isImmersive = true;
 		}
+		state = appendStateFromRequest(state, req);
 		state = appendUserState(state, req);
 		state = appendNavbarState(state);
 		state = appendSidebarState(state);

--- a/utils/state.js
+++ b/utils/state.js
@@ -2,7 +2,8 @@ module.exports = function () {
 
 	var appendStateFromRequest = function (state, req) {
 		// Append supported variables to state.
-		state.submenu = req.stateparams.submenu;
+		state.title = req.stateparams.title || {};
+		state.submenu = req.stateparams.submenu || {};
 		return state;
 	};
 

--- a/views/custom/pybits/home.jade
+++ b/views/custom/pybits/home.jade
@@ -1,0 +1,4 @@
+link(rel="stylesheet" href="/stylesheets/events.style.css")
+
+div.section.header
+	h1.title= title

--- a/views/custom/pybits/sprints.jade
+++ b/views/custom/pybits/sprints.jade
@@ -1,0 +1,4 @@
+link(rel="stylesheet" href="/stylesheets/events.style.css")
+
+div.section.header
+	h1.title= title

--- a/views/custom/pybits/talks.jade
+++ b/views/custom/pybits/talks.jade
@@ -1,0 +1,4 @@
+link(rel="stylesheet" href="/stylesheets/events.style.css")
+
+div.section.header
+	h1.title= title

--- a/views/custom/pybits/workshops.jade
+++ b/views/custom/pybits/workshops.jade
@@ -1,0 +1,4 @@
+link(rel="stylesheet" href="/stylesheets/events.style.css")
+
+div.section.header
+	h1.title= title

--- a/views/index.jade
+++ b/views/index.jade
@@ -50,15 +50,13 @@ body
 									i
 									span= val.label
 					div.secondary-wrapper
-						each val in navigation
-							if val.sub
-								div.section.secondary(_triggers=val.triggers class=val.initial)
-									label= val.label
-									ul
-										each subval in val.sub
-											li(_route="#{val.route}#{subval.route}")
-												i
-												span= subval.label
+						div.section.secondary()
+							label
+							ul
+								//- each subval in val.sub
+								//- 	li(_route="#{val.route}#{subval.route}")
+								//- 		i
+								//- 		span= subval.label
 			div.remnant.main(tabindex="1")
 				div.wrapper.face
 				div.wrapper.tray


### PR DESCRIPTION
This adds a new API, albeit with need for some refactoring, to easily create sub menus.

You pass an array of entries as `state.submenu` and a title as `state.title` to display above the submenu.

TODO: Deprecate title handling in jade params for rendering pages.