### PR TITLE
shortid: Implement shorter team IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jade": "~1.11.0",
     "marked": "^0.3.6",
     "mongoose": "^4.10.5",
+    "mongoose-shortid-nodeps": "^0.6.5",
     "morgan": "~1.8.1",
     "passport": "^0.3.2",
     "passport-facebook": "^2.1.1",

--- a/routes/api/services/events.js
+++ b/routes/api/services/events.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var express = require('express');
 var router = express.Router();
+var shortID = require('mongoose-shortid-nodeps');
 
 var eventsSchema = new Schema({
 	name: String,
@@ -16,7 +17,7 @@ var eventsSchema = new Schema({
 	contact: String,
 	startTime: Date,
 	endTime: Date,
-	teams: [String],
+	teams: [shortID],
 	price: Number,
 	route: String,
 	immersive: String,

--- a/routes/api/services/teams.js
+++ b/routes/api/services/teams.js
@@ -2,19 +2,14 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var express = require('express');
 var router = express.Router();
-var randomString = require('randomstring');
-
-var options = {
-	length: 7,
-	charset: 'alphanumeric',
-	readable: true,
-	capitalization: 'uppercase'
-};
+var shortID = require('mongoose-shortid-nodeps');
 
 var teamsSchema = new Schema({
 	_id: {
-	    type: String,
-	    'default': randomString.generate(options)
+	    type: shortID,
+	    len: 7,
+	    alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+	    retries: 500
 	},
 	name: String,
 	members: [Schema.Types.ObjectId],

--- a/routes/api/services/users.js
+++ b/routes/api/services/users.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var express = require('express');
 var router = express.Router();
+var shortID = require('mongoose-shortid-nodeps');
 
 var usersSchema = new Schema({
 	name: String,
@@ -14,7 +15,7 @@ var usersSchema = new Schema({
 	institute: {
 		type: String
 	},
-	teams: [String],
+	teams: [shortID],
 	events: [Schema.Types.ObjectId],
 	accommodation: Schema.Types.ObjectId,
 	token: String,


### PR DESCRIPTION
Changed the way by which short-ids are generated for event teams. Earlier, we were using a random string due to which the user was unable to add events to cart as the objects IDs were duplicate.