### PR TITLE
minor: Update Fuzzquire

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "~4.15.2",
     "express-session": "^1.15.3",
     "fuse.js": "^3.0.5",
-    "fuzzquire": "0.0.5",
+    "fuzzquire": "0.0.7",
     "html-entities": "^1.2.1",
     "html-pdf": "^2.1.0",
     "jade": "~1.11.0",


### PR DESCRIPTION
This new version adds two things:

1. Error Reporting: Earlier, we used to get a simple Module cannot be imported error which masked the original error. That has been changed now so that we throw the original error.
2. In Memory Loading: Earlier we used to parse the directory tree on each call to fuzzquire. Now, only the first call to it would parse the tree and store it in an environment variable. The future calls would merely read from the existing list, making execution faster.