### PR TITLE
check permission middleware on the CRUD operations

### DIFF
--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -12,7 +12,7 @@ services.push(require('./services/bodies'));
 services.push(require('./services/feed'));
 
 services.forEach(function (service) {
-	router.use(service.route, constructor(service.model, service.router));
+	router.use(service.route, constructor(service.model, service.router, service.permission));
 });
 
 var typeahead = require('./typeahead');

--- a/routes/api/services/accomm.js
+++ b/routes/api/services/accomm.js
@@ -17,8 +17,17 @@ var schema = new Schema({
 schema.plugin(require('mongoose-paginate'));
 var model = mongoose.model('accomm', schema);
 
+var permission = {
+	read_one : 0,
+	read_all : 1,
+	insert : 1,
+	update : 1,
+    delete: 2
+};
+
 module.exports = {
 	route: '/accomm',
 	model: model,
 	router: router,
+	permission: permission
 };

--- a/routes/api/services/accomm.js
+++ b/routes/api/services/accomm.js
@@ -18,11 +18,11 @@ schema.plugin(require('mongoose-paginate'));
 var model = mongoose.model('accomm', schema);
 
 var permission = {
-	read_one : 0,
-	read_all : 1,
-	insert : 1,
-	update : 1,
-    delete: 2
+	read_one: 0,
+	read_all: 1,
+	insert: 1,
+	update: 1,
+	delete: 2
 };
 
 module.exports = {

--- a/routes/api/services/bodies.js
+++ b/routes/api/services/bodies.js
@@ -29,11 +29,11 @@ schema.plugin(require('mongoose-paginate'));
 var model = mongoose.model('bodies', schema);
 
 var permission = {
-	read_one : 0,
-	read_all : 0,
-	insert : 2,
-	update : 2,
-    delete: 2
+	read_one: 0,
+	read_all: 0,
+	insert: 2,
+	update: 2,
+	delete: 2
 };
 
 module.exports = {

--- a/routes/api/services/bodies.js
+++ b/routes/api/services/bodies.js
@@ -28,8 +28,17 @@ var schema = new Schema({
 schema.plugin(require('mongoose-paginate'));
 var model = mongoose.model('bodies', schema);
 
+var permission = {
+	read_one : 0,
+	read_all : 0,
+	insert : 2,
+	update : 2,
+    delete: 2
+};
+
 module.exports = {
 	route: '/bodies',
 	model: model,
 	router: router,
+	permission: permission
 };

--- a/routes/api/services/events.js
+++ b/routes/api/services/events.js
@@ -473,8 +473,17 @@ router.post("/deletefromcart", function (req, res, next) {
 
 });
 
+var permission = {
+	read_one : 0,
+	read_all : 0,
+	insert : 1,
+	update : 1,
+    delete: 2
+};
+
 module.exports = {
 	route: '/events',
 	model: model,
 	router: router,
+	permission: permission
 };

--- a/routes/api/services/events.js
+++ b/routes/api/services/events.js
@@ -474,11 +474,11 @@ router.post("/deletefromcart", function (req, res, next) {
 });
 
 var permission = {
-	read_one : 0,
-	read_all : 0,
-	insert : 1,
-	update : 1,
-    delete: 2
+	read_one: 0,
+	read_all: 0,
+	insert: 1,
+	update: 1,
+	delete: 2
 };
 
 module.exports = {

--- a/routes/api/services/feed.js
+++ b/routes/api/services/feed.js
@@ -37,8 +37,17 @@ router.put('/add', middleware.authenticate, middleware.elevate, (req, res, next)
 	});
 });
 
+permission = {
+	read_one : 0,
+	read_all : 0
+	insert : 1,
+	update : 2,
+    delete: 2
+};
+
 module.exports = {
 	route: '/feed',
 	model: model,
 	router: router,
+	permission: permission
 };

--- a/routes/api/services/feed.js
+++ b/routes/api/services/feed.js
@@ -20,6 +20,7 @@ var schema = new Schema({
 	timestamps: true
 });
 
+schema.plugin(require('mongoose-paginate'));
 var model = mongoose.model('feed', schema);
 
 router.put('/add', middleware.authenticate, middleware.elevate, (req, res, next) => {
@@ -38,11 +39,11 @@ router.put('/add', middleware.authenticate, middleware.elevate, (req, res, next)
 });
 
 permission = {
-	read_one : 0,
-	read_all : 0,
-	insert : 1,
-	update : 2,
-    delete: 2
+	read_one: 0,
+	read_all: 0,
+	insert: 1,
+	update: 2,
+	delete: 2
 };
 
 module.exports = {

--- a/routes/api/services/feed.js
+++ b/routes/api/services/feed.js
@@ -39,7 +39,7 @@ router.put('/add', middleware.authenticate, middleware.elevate, (req, res, next)
 
 permission = {
 	read_one : 0,
-	read_all : 0
+	read_all : 0,
 	insert : 1,
 	update : 2,
     delete: 2

--- a/routes/api/services/teams.js
+++ b/routes/api/services/teams.js
@@ -27,11 +27,11 @@ schema.plugin(require('mongoose-paginate'));
 var model = mongoose.model('teams', schema);
 
 var permission = {
-	read_one : 0,
-	read_all : 0,
-	insert : 1,
-	update : 1,
-    delete: 2
+	read_one: 0,
+	read_all: 0,
+	insert: 1,
+	update: 1,
+	delete: 2
 };
 
 module.exports = {

--- a/routes/api/services/teams.js
+++ b/routes/api/services/teams.js
@@ -26,8 +26,17 @@ var schema = new Schema({
 schema.plugin(require('mongoose-paginate'));
 var model = mongoose.model('teams', schema);
 
+var permission = {
+	read_one : 0,
+	read_all : 0,
+	insert : 1,
+	update : 1,
+    delete: 2
+};
+
 module.exports = {
 	route: '/teams',
 	model: model,
 	router: router,
+	permission: permission
 };

--- a/routes/api/services/users.js
+++ b/routes/api/services/users.js
@@ -268,12 +268,12 @@ router.put('/me/', function (req, res, next) {
 	var changeddata = {};
 	changeddata = Object.assign(req.user, req.body);
 	if (req.user._id) {
-		if(changeddata.isAmbassador) {
+		if (changeddata.isAmbassador) {
 			const fs = require('fs');
 			const mail = fq('utils/mailer');
 			var emailOptions = {};
 			emailOptions.subject = "Registered as Campus Ambassador";
-			fs.readFile(path.join(base, './views/email-templates/ambassador.md'), 'utf8', function(err, data) {
+			fs.readFile(path.join(base, './views/email-templates/ambassador.md'), 'utf8', function (err, data) {
 				emailOptions.template = data;
 				mail({
 					email: req.user.email
@@ -363,11 +363,11 @@ router.post('/notifications', function (req, res, next) {
 });
 
 var permission = {
-	read_one : 0,
-	read_all : 2,
-	insert : 1,
-	update : 1,
-    delete: 2
+	read_one: 0,
+	read_all: 2,
+	insert: 1,
+	update: 1,
+	delete: 2
 };
 
 module.exports = {

--- a/routes/api/services/users.js
+++ b/routes/api/services/users.js
@@ -361,6 +361,15 @@ router.post('/notifications', function (req, res, next) {
 		});
 	});
 });
+
+var permission = {
+	read_one : 0,
+	read_all : 2,
+	insert : 1,
+	update : 1,
+    delete: 2
+};
+
 module.exports = {
 	route: '/users',
 	model: model,
@@ -370,4 +379,5 @@ module.exports = {
 		elevate: elevate,
 	},
 	addToCart: addtocart,
+	permission: permission
 };

--- a/utils/service.constructor.js
+++ b/utils/service.constructor.js
@@ -74,7 +74,7 @@ function service(model, router, permission) {
 		});
 	});
 
-	router.post('/', middleware.authenticate, checkPermission(permission.insert), function (req, res, next) {
+	router.post('/', checkPermission(permission.insert), function (req, res, next) {
 		var item = new model(req.body);
 		item.save(function (err, data) {
 			if (err) {
@@ -89,7 +89,7 @@ function service(model, router, permission) {
 		});
 	});
 
-	router.put('/', middleware.authenticate, checkPermission(permission.update), function (req, res, next) {
+	router.put('/', checkPermission(permission.update), function (req, res, next) {
 		model.update({
 			_id: req.body._id || req.body.id
 		}, req.body, function (err, data) {
@@ -105,7 +105,7 @@ function service(model, router, permission) {
 		});
 	});
 
-	router.delete('/:id', middleware.authenticate, checkPermission(permission.delete), function (req, res, next) {
+	router.delete('/:id', checkPermission(permission.delete), function (req, res, next) {
 		model.findByIdAndRemove(req.params.id, function (err, data) {
 			if (err) {
 				console.log(err);
@@ -119,7 +119,7 @@ function service(model, router, permission) {
 		});
 	});
 
-	router.put('/update-one', middleware.authenticate, checkPermission(permission.update), function (req, res, next) {
+	router.put('/update-one', checkPermission(permission.update), function (req, res, next) {
 		model.findOneAndUpdate(req.body.filter, // query
 				{
 					$set: req.body.data

--- a/utils/service.constructor.js
+++ b/utils/service.constructor.js
@@ -24,11 +24,13 @@ function checkPermission(level){
 		if(req.user.privilege >= level)
 			return next();
 		else
+		{
 			let error = new Error('Access denied');
 			error.status = 401;
 			return next(error);
-	}
-};
+		}
+	};
+}
 
 function service(model, router, permission) {
 	router.get('/', checkPermission(permission.read_all), function (req, res, next) {

--- a/utils/service.constructor.js
+++ b/utils/service.constructor.js
@@ -30,8 +30,8 @@ function checkPermission(level){
 	}
 };
 
-function service(model, router) {
-	router.get('/', checkPermission(0), function (req, res, next) {
+function service(model, router, permission) {
+	router.get('/', checkPermission(permission.read_all), function (req, res, next) {
 		var options = getOptions(req.query);
 		var promise;
 		if (req.query.page) {
@@ -48,7 +48,7 @@ function service(model, router) {
 		});
 	});
 
-	router.get('/:id',checkPermission(0), function (req, res, next) {
+	router.get('/:id', checkPermission(permission.read_one), function (req, res, next) {
 		model.findOne({
 			_id: req.params.id
 		}, function (err, item) {
@@ -61,7 +61,7 @@ function service(model, router) {
 		});
 	});
 
-	router.post('/get-one', middleware.authenticate, checkPermission(1), function (req, res, next) {
+	router.post('/get-one', middleware.authenticate, checkPermission(permission.insert), function (req, res, next) {
 		model.findOne(req.body.filter, function (err, item) {
 			if (err) {
 				console.log(err);
@@ -72,7 +72,7 @@ function service(model, router) {
 		});
 	});
 
-	router.post('/', middleware.authenticate, checkPermission(1), function (req, res, next) {
+	router.post('/', middleware.authenticate, checkPermission(permission.insert), function (req, res, next) {
 		var item = new model(req.body);
 		item.save(function (err, data) {
 			if (err) {
@@ -87,7 +87,7 @@ function service(model, router) {
 		});
 	});
 
-	router.put('/', middleware.authenticate, checkPermission(1), function (req, res, next) {
+	router.put('/', middleware.authenticate, checkPermission(permission.update), function (req, res, next) {
 		model.update({
 			_id: req.body._id || req.body.id
 		}, req.body, function (err, data) {
@@ -103,7 +103,7 @@ function service(model, router) {
 		});
 	});
 
-	router.delete('/:id', middleware.authenticate, checkPermission(2), function (req, res, next) {
+	router.delete('/:id', middleware.authenticate, checkPermission(permission.delete), function (req, res, next) {
 		model.findByIdAndRemove(req.params.id, function (err, data) {
 			if (err) {
 				console.log(err);
@@ -117,7 +117,7 @@ function service(model, router) {
 		});
 	});
 
-	router.put('/update-one', middleware.authenticate, checkPermission(1), function (req, res, next) {
+	router.put('/update-one', middleware.authenticate, checkPermission(permission.update), function (req, res, next) {
 		model.findOneAndUpdate(req.body.filter, // query
 				{
 					$set: req.body.data

--- a/utils/service.constructor.js
+++ b/utils/service.constructor.js
@@ -18,13 +18,13 @@ var getOptions = function (data) {
 	return options;
 };
 
-function checkPermission(level){
-	return function(req, res, next)
-	{
-		if(req.user.privilege >= level)
+function checkPermission(level) {
+	return function (req, res, next) {
+		if (level === 0) {
 			return next();
-		else
-		{
+		} else if (req.user && req.user.privilege && req.user.privilege.level >= level) {
+			return next();
+		} else {
 			let error = new Error('Access denied');
 			error.status = 401;
 			return next(error);


### PR DESCRIPTION
service.constructor.js :1) added the checkpermission middleware
                                 2) the basic CRUD operation now go through the middleware.authenticate and checkpermission middleware instead of middleware.elevate
/service directory: introduced and exported a new object call permission
index.js : the service.constructor is now called with three arguements latest addition being permission object