### PR TITLE
fix: Sort event names alphabetically on events page

### DIFF
--- a/routes/components/events.js
+++ b/routes/components/events.js
@@ -3,6 +3,7 @@ var router = express.Router();
 var fq = require('fuzzquire');
 var eventsService = fq("services/events").model;
 var config = fq('config-loader');
+var sort=fq('sort');
 
 var applyStateChanges = function (req) {
 	req.stateparams.title = {
@@ -39,11 +40,12 @@ router.get('/', function (req, res, next) {
 			return !elem.route.endsWith('!');
 		});
 
-		events.sort(function (a, b) {
+		/*events.sort(function (a, b) {
 			if (a.name > b.name) return -1;
 			if (a.name < b.name) return 1;
 			return 0;
-		});
+		});*/
+		events = sort(events, 'name');
 
 		res.renderState('events/home', {
 			title: 'Events',

--- a/routes/components/events.js
+++ b/routes/components/events.js
@@ -40,11 +40,6 @@ router.get('/', function (req, res, next) {
 			return !elem.route.endsWith('!');
 		});
 
-		/*events.sort(function (a, b) {
-			if (a.name > b.name) return -1;
-			if (a.name < b.name) return 1;
-			return 0;
-		});*/
 		events = sort(events, 'name');
 
 		res.renderState('events/home', {


### PR DESCRIPTION
Applied sort method to the events.js. Sorts alphabetically now.