### PR TITLE
events: Restore submenu for sections. Fix hash url history pushes.

### DIFF
--- a/forms/new-event.js
+++ b/forms/new-event.js
@@ -40,7 +40,7 @@ module.exports = function(event) {
         editable: true,
         value: event ? event.type : "",
         type: "select",
-        options: ["Headliner", "Competition", "Workshop", "Talk", "Conference", "Proshow"],
+        options: ["Competition", "Informal", "Talk", "Proshow"],
         none: true,
         group: 0,
     });

--- a/public/static/scripts/events.js
+++ b/public/static/scripts/events.js
@@ -23,22 +23,33 @@ $('document').ready(function () {
 	};
 
 	$('.section.tags a').click(function () {
-		console.log($(this).hasClass('active'));
-		if($(this).hasClass('active')) {
-			window.location.hash = "#";
+		if ($(this).hasClass('active')) {
+			window.location.hash = "#Competition";
 			$(this).removeClass('active');
 			return;
 		}
 		$(this).addClass("active").siblings().removeClass("active");
-		window.location.hash = $(this).data("tag");
+		window.location.hash = $(this).attr("href").split('#')[1];
 	});
 
 	window.onhashchange = function () {
 		if (window.location.hash.length > 1) {
-			var selector = '.event-container.' + window.location.hash.substring(1);
+
+			if (window.location.hash.startsWith("#Competition")) {
+				$('.tags').css({
+					display: 'flex'
+				}).find('a');
+			} else $('.tags').css({
+				display: 'none'
+			});
+
+			var filters = window.location.hash.substring(1).split('/');
+			var selector = '.event-container.' + filters.join('.');
+			$('.catch-filters .active').removeClass('active');
+			$('.catch-filters').find('.' + filters.join(',.')).addClass('active');
 			$('.event-container').addClass("disabled");
 			$(selector).removeClass('disabled');
-			console.log("Hash:", window.location.hash);
+
 		} else {
 			$('.event-container').removeClass("disabled");
 		}

--- a/public/static/scripts/index.js
+++ b/public/static/scripts/index.js
@@ -39,9 +39,8 @@ var manager = function () {
 		client.route(client.state.location, true, true);
 	};
 	client.route = function (route, status = true, reload = false) {
-		console.log(route);
 		if (!route) return;
-		if (route.startsWith("http") || route.startsWith("mailto") || route.startsWith("tel")) {
+		if (route.startsWith("http") || route.startsWith("tel") || route.startsWith("mailto")) {
 			window.open(route, '_self');
 			return;
 		}
@@ -49,18 +48,18 @@ var manager = function () {
 			route = '/' + route;
 		if (route.indexOf('/components') == -1)
 			route = '/components' + route;
-		console.log(route, this.state.location + (client.hash ? '#' + client.hash : ""));
 		if (route == this.state.location + (client.hash ? '#' + client.hash : "") && !reload) return;
 
 		// If not the same route, apply following logic
 		if (window.innerWidth < 800)
 			$('.window > .remnant').removeClass('shift_to_expose_menu');
-		if (!route) return;
 
 		if (route.indexOf('#') != -1) {
 			client.hash = route.split('#')[1];
 			if (route.split('#')[0] == this.state.location) {
 				window.location.hash = '#' + client.hash;
+				var url = client.state.location.replace('/components', '') + (client.hash ? '#' + client.hash : "");
+				window.history.replaceState(url, "", url);
 				return;
 			}
 		} else {
@@ -165,7 +164,7 @@ var manager = function () {
 		state.submenu.forEach(function (menuitem) {
 			var htmlstring = '<a';
 			if (menuitem.route) {
-				htmlstring += ' href="' + menuitem.route + '"';
+				htmlstring += ' class="' + menuitem.class + '" href="' + menuitem.route + '"';
 			}
 			htmlstring += '>' + '<i></i>';
 			if (menuitem.label) {
@@ -228,7 +227,6 @@ var manager = function () {
 	};
 
 	client.notifications.blur.onclick = function (e) {
-		console.log('Clicked');
 		$('#dropdown').prop('checked', false);
 	};
 	// Fetch Notifications

--- a/public/static/stylesheets/events.style.css
+++ b/public/static/stylesheets/events.style.css
@@ -292,6 +292,14 @@
     font-size:2em;
     font-weight: 600;
 }
+.module-events.open-event .back {
+    transform: rotateZ(180deg);
+    position: absolute;
+    font-size: 3em;
+    line-height: .666em;
+    right: 100%;
+    cursor: pointer;
+}
 
 .module-events.open-event .category {
     font-weight: 600;

--- a/public/static/stylesheets/home.style.css
+++ b/public/static/stylesheets/home.style.css
@@ -32,7 +32,7 @@
 .second .button::after {
     content: "GET YOUR TICKETS NOW";
 }
-a.button:hover {
+.module-home a.button:hover {
     color: #C59D5F;
     background: none !important;
 }
@@ -920,7 +920,7 @@ a.button:hover {
     cursor: pointer;
 }
 
-a.open-project {
+.module-home a.open-project {
     white-space: nowrap;
 }
 

--- a/public/static/stylesheets/index.style.css
+++ b/public/static/stylesheets/index.style.css
@@ -17,7 +17,7 @@
 }
 a, a:hover, a:visited, a:active {
     color: unset;
-    text-decoration: none;
+    text-decoration: none !important;
 }
 .button.disabled {
     pointer-events: none;
@@ -501,10 +501,9 @@ input[type = "file"] {
     display: block;
     top:0;
     width: 100%;
-    padding-top:2em;
     padding-left: inherit;
     left: 0;
-    margin-top:4.5vw;
+    padding-top: 2.5vw;
     margin-left: inherit;
     transition: inherit;
 }
@@ -517,6 +516,9 @@ input[type = "file"] {
 .window.immersive > .remnant.shift_to_expose_menu > .sidebar {
     margin-left:0;
     transition: margin-left 0.3s ease-out;
+}
+.window.immersive > .remnant.shift_to_expose_menu > .sidebar > .wrapper {
+    padding-top: 100px;
 }
 .window.immersive > .remnant.shift_to_expose_menu > .main {
     opacity: 0.7;
@@ -564,7 +566,7 @@ input[type = "file"] {
 .sidebar .section > .label {
     color: #445256;
     padding-bottom: 1em;
-    display: block;
+    display: none;
 }
 
 .sidebar .section > ul {
@@ -620,13 +622,20 @@ input[type = "file"] {
     position:relative;
 }
 
-.sidebar .secondary-wrapper > .section.secondary {
-    position:absolute;
-    opacity: 0;
-    pointer-events: none;
+.sidebar .secondary-wrapper::after {
+    content: "";
+    position: absolute;
+    width: 80%;
+    left: 10%;
+    background: #c8ae8433;
+    height: 1px;
+    top: -1.25em;
 }
-.sidebar .secondary-wrapper > .secondary > label {
-    text-transform: uppercase;
+
+.sidebar .secondary-wrapper > .section.secondary {
+    opacity: 0;
+    margin-top: 2.5em;
+    pointer-events: none;
 }
 
 .sidebar .secondary-wrapper > .secondary.disabled {
@@ -645,9 +654,7 @@ input[type = "file"] {
 .sidebar .secondary-wrapper > .secondary > ul > a {
     transform: translateX(-1em);
     opacity: 0;
-}
-.sidebar .secondary-wrapper > .secondary > ul > a > span {
-    line-height: inherit;
+    color: #c8ae84;
 }
 
 .sidebar .secondary-wrapper > .secondary.active > ul > a {

--- a/public/static/stylesheets/register-button.css
+++ b/public/static/stylesheets/register-button.css
@@ -61,7 +61,8 @@
     background:orange;
     color:#fff;
     cursor: pointer;
-    border-color:transparent;
+    border: none;
+    line-height: 2.5em;
 }
 .cart-actions .button.pending > .icon-close {
     cursor: pointer;

--- a/routes/components/events.js
+++ b/routes/components/events.js
@@ -3,13 +3,34 @@ var router = express.Router();
 var fq = require('fuzzquire');
 var eventsService = fq("services/events").model;
 var config = fq('config-loader');
-var sort=fq('sort');
+var sort = fq('sort');
 
 var applyStateChanges = function (req) {
 	req.stateparams.title = {
 		text: 'Events',
 		route: '/events',
 	};
+	req.stateparams.submenu = [{
+			route: "/events#Competition",
+			label: "Competitions",
+			class: "Competition",
+		},
+		{
+			route: "/events#Informal",
+			label: "Informals",
+			class: "Informal",
+		},
+		{
+			route: "/events#Talk",
+			label: "Talks",
+			class: "Talk",
+		},
+		{
+			route: "/events#Proshow",
+			label: "Shows",
+			class: "Show",
+		}
+	];
 	return req;
 };
 

--- a/views/events/event.jade
+++ b/views/events/event.jade
@@ -8,6 +8,8 @@ div.module-events.section.open-event(id=event._id team=(event.teamSize > 1 ? "tr
         div.hero(style="background-image:url('#{event.hero}')")
     div.body
         div.top
+            a.back(href="javascript:history.back()" absolute)
+                i.icon-navigate_next
             div.title= event.name
             div.remnant
                 +cartActionsMixin(event, user, "Register", config)

--- a/views/events/home.jade
+++ b/views/events/home.jade
@@ -23,18 +23,17 @@ div.module-events.section.header
 				span BUY TICKETS
 		- var search = {name: 'search', icon: 'search', placeholder: 'Search', editable: true};
 		+fieldMixin(search)
-	div.section.tags
-		a(data-tag="Music") Music
-		a(data-tag="Dance") Dance
-		a(data-tag="Drama") Drama
-		a(data-tag="Film") Film
-		a(data-tag="Art") Art
-		a(data-tag="Quiz") Quiz
-		a(data-tag="Writing") Writing
-		a(data-tag="Photography") Photography
-		a(data-tag="FineArts") Fine Arts
-		a(data-tag="Speaking") Speaking
-		a(data-tag="Miscellaneous") Miscellaneous
+	div.section.tags.catch-filters
+		a(href="/events#Competition/Music" class="Music") Music
+		a(href="/events#Competition/Dance" class="Dance") Dance
+		a(href="/events#Competition/Drama" class="Drama") Drama
+		a(href="/events#Competition/Film" class="Film") Film
+		a(href="/events#Competition/Art" class="Art") Art
+		a(href="/events#Competition/Quiz" class="Quiz") Quiz
+		a(href="/events#Competition/Writing" class="Writing") Writing
+		a(href="/events#Competition/Photography" class="Photography") Photography
+		a(href="/events#Competition/FineArts" class="FineArts") Fine Arts
+		a(href="/events#Competition/Miscellaneous" class="Miscellaneous") Miscellaneous
 
 div.section.events-wrapper
 	each event in events

--- a/views/index.jade
+++ b/views/index.jade
@@ -90,7 +90,7 @@ body
 					div.secondary-wrapper
 						div.section.secondary
 							a.label
-							ul
+							ul.catch-filters
 			div.remnant.main(tabindex="1")
 				div.wrapper.face
 				div.wrapper.tray


### PR DESCRIPTION
On `/events` test for freezes on navigating backwards from open events to pages where hashes are enabled.