### PR TITLE
frontend: Revert single page behavior for anchor tags.

### DIFF
--- a/public/static/scripts/index.js
+++ b/public/static/scripts/index.js
@@ -28,8 +28,7 @@ var manager = function () {
 			(e.button && e.button == 1) ||
 			$(this).attr('absolute')
 		) return true;
-		// below statement was preventing anchor tags to open links (of custom routes such as 'pybits') in the same tab( but not with ' open with new tab ').
-		//e.preventDefault(); 
+		e.preventDefault();
 		client.route($(this).attr("href"));
 		return true;
 	};

--- a/views/custom/pybits/home.jade
+++ b/views/custom/pybits/home.jade
@@ -6,11 +6,7 @@ link(rel='stylesheet', href='/static/stylesheets/events.style.css')
 link(rel='stylesheet', href='/static/stylesheets/pybits-imm.style.css')
 link(rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous")
 
-//-  jQuery, Popper.js, bootstrap js respectively 
-
-script(src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous")
-
-script(src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous")
+//- bootstrap
 
 script(src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/js/bootstrap.min.js" integrity="sha384-o+RDsa0aLu++PJvFqy8fFScvbHFLtbvScb8AjopnFD+iEQ7wo/CG0xlczd+2O/em" crossorigin="anonymous")
 
@@ -29,7 +25,7 @@ div.immersive-wrapper#pybits-background
     .text-center#heading-home.pybits-home-back PYBITS 2018
     ul#nav.list-inline.text-center
       li.list-inline-item.text-center
-        a(href="#") HOME
+        a(href="/pybits") HOME
         &nbsp;
       li.list-inline-item 
         a(href="/pybits/schedule").schedule-tab.text-center SCHEDULE


### PR DESCRIPTION
This commit fixes an accidental bug introduced in a previous commit which resulted in:
	1. All routing resulting in complete reloads of the app.
	2. Each page having two entries in the tab history stack.